### PR TITLE
fix is_writable issue in php7

### DIFF
--- a/mpdf.php
+++ b/mpdf.php
@@ -10972,7 +10972,7 @@ function _getImage(&$file, $firsttime=true, $allowvector=true, $orig_srcpath=fal
 				imagealphablending($im, false);
 				imagesavealpha($im, false); 
 				imageinterlace($im, false);
-				if (!is_writable($tempfile)) { 
+				if (!is_writable(_MPDF_TEMP_PATH)) {
 					ob_start(); 
 					$check = @imagepng($im);
 					if (!$check) { return $this->_imageError($file, $firsttime, 'Error creating temporary image object whilst using GD library to parse GIF image'); }


### PR DESCRIPTION
function is_writable was changed in php7. Now if file does not exist it returns false. Before it was checking parent directory writable status.