### PR TITLE
Fix for https://github.com/kartik-v/mpdf/issues/18

### DIFF
--- a/classes/cssmgr.php
+++ b/classes/cssmgr.php
@@ -1130,6 +1130,8 @@ function MergeCSS($inherit,$tag,$attr) {
 	$zp = array(); 
 
 	$classes = array();
+	$attr = $attr === '' ? [] : $attr;
+	
 	if (isset($attr['CLASS'])) {
 		$classes = preg_split('/\s+/',$attr['CLASS']);
 	}


### PR DESCRIPTION
Php 7.1 became more strict in type system, so it's not possible to work with variable as an array if it's already defined as string.